### PR TITLE
fuse: apply request credentials to backing operations

### DIFF
--- a/src/fuse/credentials.rs
+++ b/src/fuse/credentials.rs
@@ -1,0 +1,58 @@
+use std::io;
+
+use fuser::Request;
+
+pub(crate) struct RequestCredentials {
+    old_fsuid: libc::uid_t,
+    old_fsgid: libc::gid_t,
+}
+
+impl RequestCredentials {
+    pub(crate) fn enter(req: &Request) -> io::Result<Self> {
+        let uid = req.uid() as libc::uid_t;
+        let gid = req.gid() as libc::gid_t;
+
+        let old_fsuid = unsafe { libc::setfsuid(uid) } as libc::uid_t;
+        let current_fsuid = unsafe { libc::setfsuid(uid) } as libc::uid_t;
+
+        if current_fsuid != uid {
+            unsafe {
+                libc::setfsuid(old_fsuid);
+            }
+
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("failed to set fsuid to {uid}"),
+            ));
+        }
+
+        let old_fsgid = unsafe { libc::setfsgid(gid) } as libc::gid_t;
+        let current_fsgid = unsafe { libc::setfsgid(gid) } as libc::gid_t;
+
+        if current_fsgid != gid {
+            unsafe {
+                libc::setfsgid(old_fsgid);
+                libc::setfsuid(old_fsuid);
+            }
+
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("failed to set fsgid to {gid}"),
+            ));
+        }
+
+        Ok(Self {
+            old_fsuid,
+            old_fsgid,
+        })
+    }
+}
+
+impl Drop for RequestCredentials {
+    fn drop(&mut self) {
+        unsafe {
+            libc::setfsgid(self.old_fsgid);
+            libc::setfsuid(self.old_fsuid);
+        }
+    }
+}

--- a/src/fuse/fusefs.rs
+++ b/src/fuse/fusefs.rs
@@ -423,7 +423,7 @@ impl Filesystem for FsCache {
 
         let raw_flags = flags.0;
         if Self::is_write_intent(raw_flags) {
-            match self.open_write_handle(&path, raw_flags, 0, req.pid()) {
+            match self.open_write_handle(req, &path, raw_flags, 0, req.pid()) {
                 Ok(fd) => reply.opened(FileHandle(fd as u64), FopenFlags::empty()),
                 Err(e) => reply.error(e),
             }
@@ -478,7 +478,7 @@ impl Filesystem for FsCache {
 
         tracing::debug!(event = telemetry::EVENT_FUSE_OPEN, path = %path.display(), "fuse open");
 
-        let (fd, outcome) = match self.try_open(&path, filtered) {
+        let (fd, outcome) = match self.try_open(req, &path, filtered) {
             Ok(v) => v,
             Err(e) => {
                 reply.error(e);

--- a/src/fuse/mod.rs
+++ b/src/fuse/mod.rs
@@ -1,3 +1,4 @@
+mod credentials;
 pub mod fusefs;
 mod inode;
 pub(crate) mod util;

--- a/src/fuse/read.rs
+++ b/src/fuse/read.rs
@@ -9,12 +9,17 @@ use fuser::{
 
 use crate::discovery::OpKind;
 use crate::telemetry;
+use crate::fuse::credentials::RequestCredentials;
 
 use super::fusefs::{FsCache, OpenOutcome, TTL};
 use super::util::{abs_to_cstring, io_to_errno, last_errno, rel_to_cstring};
 
 impl FsCache {
-    pub(crate) fn try_open(&self, path: &Path, filtered: bool) -> Result<(i32, OpenOutcome), Errno> {
+    pub(crate) fn try_open(&self,
+        req: &Request,
+        path: &Path,
+        filtered: bool
+    ) -> Result<(i32, OpenOutcome), Errno> {
         if !self.passthrough_mode
             && let Some(ref cache) = self.cache
             && cache.is_cached(path)
@@ -33,6 +38,8 @@ impl FsCache {
                 "cache hit race, falling back to backing store"
             );
         }
+
+        let _credentials = RequestCredentials::enter(req).map_err(io_to_errno)?;
 
         let fd = self
             .backing_store
@@ -212,6 +219,13 @@ impl FsCache {
             rel_to_cstring(Path::new("."))
         } else {
             rel_to_cstring(&path)
+        };
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
         };
         let fd = unsafe {
             libc::openat(

--- a/src/fuse/write.rs
+++ b/src/fuse/write.rs
@@ -11,15 +11,20 @@ use fuser::{
 
 use super::fusefs::{apply_umask, time_or_now_to_timespec, FsCache, TTL};
 use super::util::{io_to_errno, last_errno};
+use super::credentials::RequestCredentials;
 
 impl FsCache {
     pub(crate) fn open_write_handle(
         &self,
+        req: &Request,
         path: &Path,
         flags: i32,
         mode: u32,
         pid: u32,
     ) -> Result<RawFd, Errno> {
+        let _credentials =
+            super::credentials::RequestCredentials::enter(req).map_err(io_to_errno)?;
+
         let fd = self
             .backing_store
             .open_file_with_flags(path, flags, mode)
@@ -124,7 +129,7 @@ impl FsCache {
 
     pub(crate) fn do_mknod(
         &self,
-        _req: &Request,
+        req: &Request,
         parent: INodeNo,
         name: &OsStr,
         mode: u32,
@@ -132,6 +137,13 @@ impl FsCache {
         rdev: u32,
         reply: ReplyEntry,
     ) {
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
+        };
         let path = match self.child_path(parent, name) {
             Ok(path) => path,
             Err(e) => {
@@ -155,13 +167,20 @@ impl FsCache {
 
     pub(crate) fn do_mkdir(
         &self,
-        _req: &Request,
+        req: &Request,
         parent: INodeNo,
         name: &OsStr,
         mode: u32,
         umask: u32,
         reply: ReplyEntry,
     ) {
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
+        };
         let path = match self.child_path(parent, name) {
             Ok(path) => path,
             Err(e) => {
@@ -183,11 +202,18 @@ impl FsCache {
         }
     }
 
-    pub(crate) fn do_unlink(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    pub(crate) fn do_unlink(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         let path = match self.child_path(parent, name) {
             Ok(path) => path,
             Err(e) => {
                 reply.error(e);
+                return;
+            }
+        };
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
                 return;
             }
         };
@@ -199,11 +225,18 @@ impl FsCache {
         reply.ok();
     }
 
-    pub(crate) fn do_rmdir(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
+    pub(crate) fn do_rmdir(&self, req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEmpty) {
         let path = match self.child_path(parent, name) {
             Ok(path) => path,
             Err(e) => {
                 reply.error(e);
+                return;
+            }
+        };
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
                 return;
             }
         };
@@ -217,12 +250,19 @@ impl FsCache {
 
     pub(crate) fn do_symlink(
         &self,
-        _req: &Request,
+        req: &Request,
         parent: INodeNo,
         link_name: &OsStr,
         target: &Path,
         reply: ReplyEntry,
     ) {
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
+        };
         let path = match self.child_path(parent, link_name) {
             Ok(path) => path,
             Err(e) => {
@@ -246,7 +286,7 @@ impl FsCache {
 
     pub(crate) fn do_rename(
         &self,
-        _req: &Request,
+        req: &Request,
         parent: INodeNo,
         name: &OsStr,
         newparent: INodeNo,
@@ -254,6 +294,13 @@ impl FsCache {
         flags: RenameFlags,
         reply: ReplyEmpty,
     ) {
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
+        };
         let old = match self.child_path(parent, name) {
             Ok(path) => path,
             Err(e) => {
@@ -282,12 +329,19 @@ impl FsCache {
 
     pub(crate) fn do_link(
         &self,
-        _req: &Request,
+        req: &Request,
         ino: INodeNo,
         newparent: INodeNo,
         newname: &OsStr,
         reply: ReplyEntry,
     ) {
+        let _credentials = match RequestCredentials::enter(req) {
+            Ok(credentials) => credentials,
+            Err(e) => {
+                reply.error(io_to_errno(e));
+                return;
+            }
+        };
         let old = match self.path_for_ino(ino) {
             Ok(path) => path,
             Err(e) => {
@@ -383,6 +437,7 @@ impl FsCache {
             }
         };
         let fd = match self.open_write_handle(
+            req,
             &path,
             flags | libc::O_CREAT,
             apply_umask(mode, umask),

--- a/src/main.rs
+++ b/src/main.rs
@@ -315,6 +315,7 @@ async fn run_daemon(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     let mut fuse_config = fuser::Config::default();
     fuse_config.mount_options = vec![
         MountOption::AutoUnmount,
+        MountOption::DefaultPermissions,
         MountOption::FSName(format!("fscache-{}", instance_name)),
     ];
     fuse_config.acl = SessionACL::All;

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -344,7 +344,6 @@ impl OvermountHarness {
         // Clean unmount is guaranteed by drop ordering: _session drops first.
         let mut config = fuser::Config::default();
         config.mount_options = vec![
-            MountOption::CUSTOM("nonempty".to_string()),
             MountOption::FSName("fscache-overmount-test".to_string()),
         ];
         config.acl = SessionACL::Owner;


### PR DESCRIPTION
This change applies the credentials from the FUSE request to backing filesystem operations.
This ensures that filesystem access is performed with the requesting user's fsuid/fsgid rather than the daemon's credentials.
Changes include:
- Apply request credentials to file open/read/write operations
- Apply credentials to filesystem mutations such as mkdir, unlink, rmdir, symlink, rename, link and mknod
- Enable DefaultPermissions on the production FUSE mount
- Remove the obsolete nonempty FUSE mount option from the overmount test harness
- Add an overmount integration test covering the affected behavior

All tests pass.